### PR TITLE
Disabling CI on push to main

### DIFF
--- a/.github/workflows/ci-as-lint.yml
+++ b/.github/workflows/ci-as-lint.yml
@@ -1,8 +1,5 @@
 name: ci-as-lint
 on:
-  push:
-    branches:
-      - main
   pull_request:
     types:
       - opened


### PR DESCRIPTION
Disabling .github/workflows/ci-as-lint.yml on Push to main. 
"Require branches to be up to date before merging" check in enabled on branch protection, hence no risk of disabling these on push