### PR TITLE
Add build metadata to wasm at compilation time

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,6 +5,9 @@
     "[typescript]": {
         "editor.defaultFormatter": "esbenp.prettier-vscode"
     },
+    "[javascript]": {
+        "editor.defaultFormatter": "esbenp.prettier-vscode"
+    },
     "[graphql]": {
         "editor.formatOnSave": false
     }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,6 +8,9 @@
     "[javascript]": {
         "editor.defaultFormatter": "esbenp.prettier-vscode"
     },
+    "[json]": {
+        "editor.defaultFormatter": "esbenp.prettier-vscode"
+    },
     "[graphql]": {
         "editor.formatOnSave": false
     }

--- a/examples/hmplugin1/asconfig.json
+++ b/examples/hmplugin1/asconfig.json
@@ -18,10 +18,7 @@
     }
   },
   "options": {
-    "transform": [
-      "@hypermode/functions-as/transform",
-      "json-as/transform"
-    ],
+    "transform": ["@hypermode/functions-as/transform", "json-as/transform"],
     "exportRuntime": true
   }
 }

--- a/examples/hmplugin1/asconfig.json
+++ b/examples/hmplugin1/asconfig.json
@@ -18,7 +18,10 @@
     }
   },
   "options": {
-    "transform": ["json-as/transform"],
+    "transform": [
+      "@hypermode/functions-as/transform",
+      "json-as/transform"
+    ],
     "exportRuntime": true
   }
 }

--- a/src/asconfig.json
+++ b/src/asconfig.json
@@ -1,5 +1,5 @@
 {
   "options": {
-    "transform": ["json-as/transform"]
+    "transform": ["./transform", "json-as/transform"]
   }
 }

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.2.2",
       "license": "MIT",
       "dependencies": {
-        "json-as": "^0.7.3"
+        "json-as": "^0.7.3",
+        "xid-ts": "^1.1.0"
       },
       "devDependencies": {
         "@as-pect/cli": "^8.1.0",
@@ -7190,6 +7191,14 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true
+    },
+    "node_modules/xid-ts": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/xid-ts/-/xid-ts-1.1.0.tgz",
+      "integrity": "sha512-MVMypK+qLyDscU/gt1Y7vR8puZ+C6OL1NxNpumKUlziifoVHjJxwLAi7gRWbKIlEU/LTwrPLnnqnw0SAisVkqQ==",
+      "engines": {
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/yallist": {
       "version": "4.0.0",

--- a/src/package.json
+++ b/src/package.json
@@ -13,7 +13,8 @@
     "lint:fix": "eslint --ext .ts --fix ."
   },
   "dependencies": {
-    "json-as": "^0.7.3"
+    "json-as": "^0.7.3",
+    "xid-ts": "^1.1.0"
   },
   "devDependencies": {
     "@as-pect/cli": "^8.1.0",

--- a/src/transform.js
+++ b/src/transform.js
@@ -1,0 +1,82 @@
+import { Transform } from "assemblyscript/transform";
+import { TextEncoder } from "util";
+import { readFileSync } from "fs";
+import { fileURLToPath } from "url";
+import { dirname, join } from "path";
+import { execSync } from "child_process";
+import { Xid } from "xid-ts";
+import process from "process";
+
+// This transform adds metadata to the compiled wasm file, as custom sections.
+
+export default class HypermodeTransform extends Transform {
+  afterCompile(module) {
+    // Setup for adding UTF-8 strings in wasm custom sections.
+    const encoder = new TextEncoder();
+    const addInfo = (name, data) => {
+      module.addCustomSection(name, encoder.encode(data));
+    };
+
+    // Add metadata.
+    addInfo("build_id", getBuildId());
+    addInfo("build_ts", getBuildTimestamp());
+    addInfo("hypermode_library", getHypermodeInfo());
+    addInfo("hypermode_plugin", getPluginInfo());
+
+    // Add git metadata if available.
+    if (isGitRepo()) {
+      addInfo("git_repo", getGitRepo());
+      addInfo("git_commit", getGitCommit());
+    }
+  }
+}
+
+function getBuildId() {
+  return new Xid().toString();
+}
+
+function getBuildTimestamp() {
+  return new Date().toISOString();
+}
+
+function getHypermodeInfo() {
+  const path = join(dirname(fileURLToPath(import.meta.url)), "package.json");
+  const lib = JSON.parse(readFileSync(path));
+  return `${lib.name}@${lib.version}`;
+}
+
+function getPluginInfo() {
+  const pluginName = process.env.npm_package_name;
+  const pluginVersion = process.env.npm_package_version;
+  return `${pluginName}@${pluginVersion}`;
+}
+
+function isGitRepo() {
+  try {
+    // This will throw if not in a git repo, or if git is not installed.
+    execSync("git rev-parse --is-inside-work-tree", { stdio: "ignore" });
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
+
+function getGitRepo() {
+  let url = execSync("git remote get-url origin").toString().trim();
+
+  // Convert ssh to https
+  if (url.startsWith("git@")) {
+    url = url.replace(":", "/").replace("git@", "https://");
+  }
+
+  // Remove the .git suffix
+  if (url.endsWith(".git")) {
+    url = url.slice(0, -4);
+  }
+
+  return url;
+}
+
+function getGitCommit() {
+  return execSync("git rev-parse HEAD").toString().trim();
+}


### PR DESCRIPTION
Completes HYP-780

Example of data added to resulting WASM (WAT):

```
 ;; custom section "build_id", size 20, contents: "cnpjge83qsmnkci2lal0"
 ;; custom section "build_ts", size 24, contents: "2024-03-14T17:47:37.880Z"
 ;; custom section "hypermode_library", size 29, contents: "@hypermode/functions-as@0.2.2"
 ;; custom section "hypermode_plugin", size 15, contents: "hmplugin1@1.0.0"
 ;; custom section "git_repo", size 43, contents: "https://github.com/gohypermode/functions-as"
 ;; custom section "git_commit", size 40, contents: "3bd1c38cc3e120470ce1593b361d361f712df06b"
```