### PR TITLE
linting / formatting

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,7 +1,7 @@
 {
-    "recommendations": [
-        "esbenp.prettier-vscode",
-        "dbaeumer.vscode-eslint",
-        "streetsidesoftware.code-spell-checker"
-    ]
+  "recommendations": [
+    "esbenp.prettier-vscode",
+    "dbaeumer.vscode-eslint",
+    "streetsidesoftware.code-spell-checker"
+  ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,17 +1,20 @@
 {
-    "editor.formatOnSave": true,
-    "files.insertFinalNewline": true,
-    "files.trimFinalNewlines": true,
-    "[typescript]": {
-        "editor.defaultFormatter": "esbenp.prettier-vscode"
-    },
-    "[javascript]": {
-        "editor.defaultFormatter": "esbenp.prettier-vscode"
-    },
-    "[json]": {
-        "editor.defaultFormatter": "esbenp.prettier-vscode"
-    },
-    "[graphql]": {
-        "editor.formatOnSave": false
-    }
+  "editor.formatOnSave": true,
+  "files.insertFinalNewline": true,
+  "files.trimFinalNewlines": true,
+  "[typescript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[javascript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[json]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[jsonc]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[graphql]": {
+    "editor.formatOnSave": false
+  }
 }

--- a/examples/hmplugin1/.eslintrc.json
+++ b/examples/hmplugin1/.eslintrc.json
@@ -8,6 +8,5 @@
     "ecmaVersion": "latest",
     "sourceType": "module"
   },
-  "plugins": ["@typescript-eslint"],
-  "rules": {}
+  "plugins": ["@typescript-eslint"]
 }

--- a/src/.eslintrc.json
+++ b/src/.eslintrc.json
@@ -9,5 +9,11 @@
     "sourceType": "module"
   },
   "plugins": ["@typescript-eslint"],
-  "rules": {}
+  "ignorePatterns": ["*.cjs"],
+  "overrides": [
+    {
+      "files": ["./assembly/**/*.ts"],
+      "parser": "./eslintParser.cjs"
+    }
+  ]
 }

--- a/src/assembly/hypermode.ts
+++ b/src/assembly/hypermode.ts
@@ -1,3 +1,6 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-nocheck: decorators are allowed on function exports in AssemblyScript
+
 // This file should only export functions from the "hypermode" host module.
 
 export declare function executeDQL(

--- a/src/eslintParser.cjs
+++ b/src/eslintParser.cjs
@@ -1,0 +1,15 @@
+const parser = require("@typescript-eslint/parser");
+module.exports = { ...parser };
+
+const utils = require("./node_modules/@typescript-eslint/typescript-estree/dist/node-utils.js");
+const ts = require("typescript");
+
+// In AssemblyScript, functions can be decorated
+nodeCanBeDecorated = utils.nodeCanBeDecorated;
+utils.nodeCanBeDecorated = function (node) {
+  if (node.kind == ts.SyntaxKind.FunctionDeclaration) {
+    return true;
+  }
+
+  return nodeCanBeDecorated(node);
+};


### PR DESCRIPTION
Adds a custom eslint parser for the src project, so we can later use things like `@external` on our host function declarations for name aliasing, without getting linting errors.