### PR TITLE
Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,12 @@ updates:
       interval: "daily"
     allow:
       - dependency-type: "production"
+    groups:
+      minor-and-patch:
+        applies-to: version-updates
+        update-types:
+        - "minor"
+        - "patch"
 
   - package-ecosystem: "github-actions"
     # Workflow files stored in the default location of `.github/workflows`. (You don't need to specify `/.github/workflows` for `directory`. You can use `directory: "/"`.)


### PR DESCRIPTION
Simplifying Dependabot PRs by grouping minor and patch bumps into a single PR. Major bumps and security-driven updates will continue to update in dedicated PRs.