### PR TITLE
Clean up build for example plugin

### DIFF
--- a/examples/hmplugin1/asconfig.json
+++ b/examples/hmplugin1/asconfig.json
@@ -1,24 +1,19 @@
 {
   "extends": "./node_modules/@assemblyscript/wasi-shim/asconfig.json",
+  "options": {
+    "transform": ["@hypermode/functions-as/transform", "json-as/transform"],
+    "exportRuntime": true
+  },
   "targets": {
     "debug": {
-      "outFile": "build/debug.wasm",
-      "textFile": "build/debug.wat",
       "sourceMap": true,
       "debug": true
     },
     "release": {
-      "outFile": "build/release.wasm",
-      "textFile": "build/release.wat",
-      "sourceMap": true,
       "optimizeLevel": 3,
       "shrinkLevel": 0,
       "converge": false,
       "noAssert": false
     }
-  },
-  "options": {
-    "transform": ["@hypermode/functions-as/transform", "json-as/transform"],
-    "exportRuntime": true
   }
 }

--- a/examples/hmplugin1/package-lock.json
+++ b/examples/hmplugin1/package-lock.json
@@ -20,6 +20,7 @@
         "assemblyscript-prettier": "^3.0.1",
         "eslint": "^8.57.0",
         "prettier": "^3.2.5",
+        "run-script-os": "^1.1.6",
         "visitor-as": "^0.11.4"
       }
     },
@@ -1585,6 +1586,16 @@
       ],
       "dependencies": {
         "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/run-script-os": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/run-script-os/-/run-script-os-1.1.6.tgz",
+      "integrity": "sha512-ql6P2LzhBTTDfzKts+Qo4H94VUKpxKDFz6QxxwaUZN0mwvi7L3lpOI7BqPCq7lgDh3XLl0dpeXwfcVIitlrYrw==",
+      "dev": true,
+      "bin": {
+        "run-os": "index.js",
+        "run-script-os": "index.js"
       }
     },
     "node_modules/semver": {

--- a/examples/hmplugin1/package.json
+++ b/examples/hmplugin1/package.json
@@ -6,9 +6,10 @@
   "license": "MIT",
   "type": "module",
   "scripts": {
-    "build:debug": "asc assembly/index.ts --target debug",
-    "build:release": "asc assembly/index.ts --target release",
-    "build": "npm run build:debug && npm run build:release",
+    "build": "run-script-os",
+    "build:windows": "asc assembly\\index.ts -o build\\%npm_package_name%.wasm --target debug",
+    "build:default": "asc assembly/index.ts -o build/$npm_package_name.wasm --target debug",
+    "build:release": "asc assembly/index.ts -o build/$npm_package_name.wasm --target release",
     "pretty": "prettier --write .",
     "pretty:check": "prettier --check .",
     "lint": "eslint --ext .ts .",
@@ -26,6 +27,7 @@
     "assemblyscript-prettier": "^3.0.1",
     "eslint": "^8.57.0",
     "prettier": "^3.2.5",
+    "run-script-os": "^1.1.6",
     "visitor-as": "^0.11.4"
   },
   "overrides": {


### PR DESCRIPTION
We don't need to build both debug and release versions every time.

- We'll build the debug version by default with `npm run build`.
  - Don't apply any compiler optimizations
  - Generate a source map (though we still need to figure out how to use them)
  - Should work cross-platform for developer experience.

- We'll use the release version for deployment, with `npm run build:release`.
  - Apply compiler optimizations
  - No need for a source map
  - Doesn't need to work cross-platform, as we will typically run in CI on Linux only.

For both:
- We don't need the `.wat` text output, as we only use `.wasm` in Hypermode.
- The generated wasm file name should match the plugin name so they can easier be identified in a directory or s3 bucket.