### PR TITLE
Support parameters of different types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+# UNRELEASED
+
+- **(BREAKING)** Support query parameters of different types. [#40](https://github.com/gohypermode/functions-as/pull/40)
+
 # 2024-03-22 - Version 0.4.0
 
 - Adds `model.generate<TData>` and `model.generateList<TData>` [#30](https://github.com/gohypermode/functions-as/pull/30)

--- a/examples/hmplugin1/assembly/index.ts
+++ b/examples/hmplugin1/assembly/index.ts
@@ -4,6 +4,7 @@ import {
   graphql,
   model,
   ClassificationResult,
+  QueryParameters,
 } from "@hypermode/functions-as";
 
 export function add(a: i32, b: i32): i32 {
@@ -55,11 +56,12 @@ export function queryPeopleWithVars(
     }
   `;
 
-  const vars = new Map<string, string>();
-  vars.set("$firstName", firstName);
-  vars.set("$lastName", lastName);
+  const parameters = new QueryParameters();
+  parameters.set("$firstName", firstName);
+  parameters.set("$lastName", lastName);
+  parameters.set("test", 123);
 
-  const response = dql.query<PeopleData>(query, vars);
+  const response = dql.query<PeopleData>(query, parameters);
   const people = response.data.people;
   people.forEach((p) => p.updateFullName());
   return JSON.stringify(people);

--- a/examples/hmplugin1/assembly/index.ts
+++ b/examples/hmplugin1/assembly/index.ts
@@ -59,7 +59,6 @@ export function queryPeopleWithVars(
   const parameters = new QueryParameters();
   parameters.set("$firstName", firstName);
   parameters.set("$lastName", lastName);
-  parameters.set("test", 123);
 
   const response = dql.query<PeopleData>(query, parameters);
   const people = response.data.people;

--- a/src/assembly/__tests__/queryparams.spec.ts
+++ b/src/assembly/__tests__/queryparams.spec.ts
@@ -1,0 +1,18 @@
+import { QueryParameters } from "..";
+
+describe("Query Parameters Object", () => {
+  it("can serialize", () => {
+    const params = new QueryParameters();
+    params.set("key1", "abc");
+    params.set("key2", 123);
+    params.set("key3", true);
+    params.set("key4", [123, 456, 789]);
+    params.set("key5", [1.234, 2.345, 3.456]);
+
+    const result = params.toJSON();
+
+    const expected = `{"key1":"abc","key2":123,"key3":true,"key4":[123,456,789],"key5":[1.234,2.345,3.456]}`;
+
+    expect(result).toBe(expected);
+  });
+});

--- a/src/assembly/hypermode.ts
+++ b/src/assembly/hypermode.ts
@@ -5,13 +5,13 @@
 
 export declare function executeDQL(
   statement: string,
-  variables: string,
+  parameters: string,
   isMutation: bool,
 ): string;
 
 export declare function executeGQL(
   statement: string,
-  variables: string,
+  parameters: string,
 ): string;
 
 export declare function invokeClassifier(

--- a/src/assembly/index.ts
+++ b/src/assembly/index.ts
@@ -1,7 +1,10 @@
 import * as host from "./hypermode";
 import { DQLResponse, DQLMutationResponse } from "./dqltypes";
 import { GQLResponse } from "./gqltypes";
+import { QueryParameters } from "./queryparams";
 import { JSON } from "json-as";
+
+export { QueryParameters };
 
 const UNCERTAIN_LABEL = "UNCERTAIN";
 const UNCERTAIN_PROBABILITY = f32(1.0);
@@ -9,25 +12,25 @@ const UNCERTAIN_PROBABILITY = f32(1.0);
 export abstract class dql {
   public static mutate(
     query: string,
-    variables: Map<string, string> = new Map<string, string>(),
+    parameters: QueryParameters = new QueryParameters(),
   ): DQLResponse<DQLMutationResponse> {
-    return this.execute<DQLMutationResponse>(true, query, variables);
+    return this.execute<DQLMutationResponse>(true, query, parameters);
   }
 
   public static query<TData>(
     query: string,
-    variables: Map<string, string> = new Map<string, string>(),
+    parameters: QueryParameters = new QueryParameters(),
   ): DQLResponse<TData> {
-    return this.execute<TData>(false, query, variables);
+    return this.execute<TData>(false, query, parameters);
   }
 
   private static execute<TData>(
     isMutation: bool,
     query: string,
-    variables: Map<string, string> = new Map<string, string>(),
+    parameters: QueryParameters,
   ): DQLResponse<TData> {
-    const variablesJson = JSON.stringify(variables);
-    const response = host.executeDQL(query, variablesJson, isMutation);
+    const paramsJson = parameters.toJSON();
+    const response = host.executeDQL(query, paramsJson, isMutation);
     return JSON.parse<DQLResponse<TData>>(response);
   }
 }
@@ -35,10 +38,10 @@ export abstract class dql {
 export abstract class graphql {
   static execute<TData>(
     statement: string,
-    variables: Map<string, string> = new Map<string, string>(),
+    parameters: QueryParameters = new QueryParameters(),
   ): GQLResponse<TData> {
-    const variablesJson = JSON.stringify(variables);
-    const response = host.executeGQL(statement, variablesJson);
+    const paramsJson = parameters.toJSON();
+    const response = host.executeGQL(statement, paramsJson);
     return JSON.parse<GQLResponse<TData>>(response);
   }
 }

--- a/src/assembly/queryparams.ts
+++ b/src/assembly/queryparams.ts
@@ -48,7 +48,7 @@ export class QueryParameters {
         segments.push(`${key}:${JSON.stringify(value.get<i16>())}`);
       } else if (value.is<u16>()) {
         segments.push(`${key}:${JSON.stringify(value.get<u16>())}`);
-      } else if (value.is<string>()) {
+      } else if (value.is<string[]>()) {
         segments.push(`${key}:${JSON.stringify(value.get<string[]>())}`);
       } else if (value.is<bool[]>()) {
         segments.push(`${key}:${JSON.stringify(value.get<bool[]>())}`);

--- a/src/assembly/queryparams.ts
+++ b/src/assembly/queryparams.ts
@@ -26,54 +26,87 @@ export class QueryParameters {
       const key = JSON.stringify(keys[i]);
       const value = values[i];
 
-      if (value.is<string>()) {
-        segments.push(`${key}:${JSON.stringify(value.get<string>())}`);
-      } else if (value.is<bool>()) {
-        segments.push(`${key}:${JSON.stringify(value.get<bool>())}`);
-      } else if (value.is<i32>()) {
-        segments.push(`${key}:${JSON.stringify(value.get<i32>())}`);
-      } else if (value.is<u32>()) {
-        segments.push(`${key}:${JSON.stringify(value.get<u32>())}`);
-      } else if (value.is<i64>()) {
-        segments.push(`${key}:${JSON.stringify(value.get<i64>())}`);
-      } else if (value.is<f32>()) {
-        segments.push(`${key}:${JSON.stringify(value.get<f32>())}`);
-      } else if (value.is<f64>()) {
-        segments.push(`${key}:${JSON.stringify(value.get<f64>())}`);
-      } else if (value.is<i8>()) {
-        segments.push(`${key}:${JSON.stringify(value.get<i8>())}`);
-      } else if (value.is<u8>()) {
-        segments.push(`${key}:${JSON.stringify(value.get<u8>())}`);
-      } else if (value.is<i16>()) {
-        segments.push(`${key}:${JSON.stringify(value.get<i16>())}`);
-      } else if (value.is<u16>()) {
-        segments.push(`${key}:${JSON.stringify(value.get<u16>())}`);
-      } else if (value.is<string[]>()) {
-        segments.push(`${key}:${JSON.stringify(value.get<string[]>())}`);
-      } else if (value.is<bool[]>()) {
-        segments.push(`${key}:${JSON.stringify(value.get<bool[]>())}`);
-      } else if (value.is<i32[]>()) {
-        segments.push(`${key}:${JSON.stringify(value.get<i32[]>())}`);
-      } else if (value.is<u32[]>()) {
-        segments.push(`${key}:${JSON.stringify(value.get<u32[]>())}`);
-      } else if (value.is<i64[]>()) {
-        segments.push(`${key}:${JSON.stringify(value.get<i64[]>())}`);
-      } else if (value.is<f32[]>()) {
-        segments.push(`${key}:${JSON.stringify(value.get<f32[]>())}`);
-      } else if (value.is<f64[]>()) {
-        segments.push(`${key}:${JSON.stringify(value.get<f64[]>())}`);
-      } else if (value.is<i8[]>()) {
-        segments.push(`${key}:${JSON.stringify(value.get<i8[]>())}`);
-      } else if (value.is<u8[]>()) {
-        segments.push(`${key}:${JSON.stringify(value.get<u8[]>())}`);
-      } else if (value.is<i16[]>()) {
-        segments.push(`${key}:${JSON.stringify(value.get<i16[]>())}`);
-      } else if (value.is<u16[]>()) {
-        segments.push(`${key}:${JSON.stringify(value.get<u16[]>())}`);
-      } else {
-        throw new Error(
-          "Query parameters must be simple types, or arrays of simple types.",
-        );
+      switch (value.id) {
+        // Simple types
+        case Variant.idof<string>():
+          segments.push(`${key}:${JSON.stringify(value.get<string>())}`);
+          break;
+        case Variant.idof<bool>():
+          segments.push(`${key}:${JSON.stringify(value.get<bool>())}`);
+          break;
+        case Variant.idof<f64>():
+          segments.push(`${key}:${JSON.stringify(value.get<f64>())}`);
+          break;
+        case Variant.idof<f32>():
+          segments.push(`${key}:${JSON.stringify(value.get<f32>())}`);
+          break;
+        case Variant.idof<i64>():
+          segments.push(`${key}:${JSON.stringify(value.get<i64>())}`);
+          break;
+        case Variant.idof<i32>():
+          segments.push(`${key}:${JSON.stringify(value.get<i32>())}`);
+          break;
+        case Variant.idof<i16>():
+          segments.push(`${key}:${JSON.stringify(value.get<i16>())}`);
+          break;
+        case Variant.idof<i8>():
+          segments.push(`${key}:${JSON.stringify(value.get<i8>())}`);
+          break;
+        case Variant.idof<u64>():
+          segments.push(`${key}:${JSON.stringify(value.get<u64>())}`);
+          break;
+        case Variant.idof<u32>():
+          segments.push(`${key}:${JSON.stringify(value.get<u32>())}`);
+          break;
+        case Variant.idof<u16>():
+          segments.push(`${key}:${JSON.stringify(value.get<u16>())}`);
+          break;
+        case Variant.idof<u8>():
+          segments.push(`${key}:${JSON.stringify(value.get<u8>())}`);
+          break;
+
+        // Arrays of simple types
+        case Variant.idof<string[]>():
+          segments.push(`${key}:${JSON.stringify(value.get<string[]>())}`);
+          break;
+        case Variant.idof<bool[]>():
+          segments.push(`${key}:${JSON.stringify(value.get<bool[]>())}`);
+          break;
+        case Variant.idof<f64[]>():
+          segments.push(`${key}:${JSON.stringify(value.get<f64[]>())}`);
+          break;
+        case Variant.idof<f32[]>():
+          segments.push(`${key}:${JSON.stringify(value.get<f32[]>())}`);
+          break;
+        case Variant.idof<i64[]>():
+          segments.push(`${key}:${JSON.stringify(value.get<i64[]>())}`);
+          break;
+        case Variant.idof<i32[]>():
+          segments.push(`${key}:${JSON.stringify(value.get<i32[]>())}`);
+          break;
+        case Variant.idof<i16[]>():
+          segments.push(`${key}:${JSON.stringify(value.get<i16[]>())}`);
+          break;
+        case Variant.idof<i8[]>():
+          segments.push(`${key}:${JSON.stringify(value.get<i8[]>())}`);
+          break;
+        case Variant.idof<u64[]>():
+          segments.push(`${key}:${JSON.stringify(value.get<u64[]>())}`);
+          break;
+        case Variant.idof<u32[]>():
+          segments.push(`${key}:${JSON.stringify(value.get<u32[]>())}`);
+          break;
+        case Variant.idof<u16[]>():
+          segments.push(`${key}:${JSON.stringify(value.get<u16[]>())}`);
+          break;
+        case Variant.idof<u8[]>():
+          segments.push(`${key}:${JSON.stringify(value.get<u8[]>())}`);
+          break;
+
+        default:
+          throw new Error(
+            "Query parameters must be simple types, or arrays of simple types.",
+          );
       }
     }
 

--- a/src/assembly/queryparams.ts
+++ b/src/assembly/queryparams.ts
@@ -1,0 +1,82 @@
+import { Variant } from "as-variant/assembly";
+import { JSON } from "json-as";
+
+export class QueryParameters {
+  private parameters: Map<string, Variant> = new Map<string, Variant>();
+
+  public set<T>(name: string, value: T): void {
+    this.parameters.set(name, Variant.from(value));
+  }
+
+  public toJSON(): string {
+    /*
+    The following would be ideal but is not currently supported:
+      
+        return JSON.stringify(this.parameters);
+    
+    See https://github.com/JairusSW/as-json/issues/64
+    Instead, we have to manually create a JSON string.
+    */
+    const segments: string[] = [];
+
+    const keys = this.parameters.keys();
+    const values = this.parameters.values();
+
+    for (let i = 0; i < this.parameters.size; i++) {
+      const key = JSON.stringify(keys[i]);
+      const value = values[i];
+
+      if (value.is<string>()) {
+        segments.push(`${key}:${JSON.stringify(value.get<string>())}`);
+      } else if (value.is<bool>()) {
+        segments.push(`${key}:${JSON.stringify(value.get<bool>())}`);
+      } else if (value.is<i32>()) {
+        segments.push(`${key}:${JSON.stringify(value.get<i32>())}`);
+      } else if (value.is<u32>()) {
+        segments.push(`${key}:${JSON.stringify(value.get<u32>())}`);
+      } else if (value.is<i64>()) {
+        segments.push(`${key}:${JSON.stringify(value.get<i64>())}`);
+      } else if (value.is<f32>()) {
+        segments.push(`${key}:${JSON.stringify(value.get<f32>())}`);
+      } else if (value.is<f64>()) {
+        segments.push(`${key}:${JSON.stringify(value.get<f64>())}`);
+      } else if (value.is<i8>()) {
+        segments.push(`${key}:${JSON.stringify(value.get<i8>())}`);
+      } else if (value.is<u8>()) {
+        segments.push(`${key}:${JSON.stringify(value.get<u8>())}`);
+      } else if (value.is<i16>()) {
+        segments.push(`${key}:${JSON.stringify(value.get<i16>())}`);
+      } else if (value.is<u16>()) {
+        segments.push(`${key}:${JSON.stringify(value.get<u16>())}`);
+      } else if (value.is<string>()) {
+        segments.push(`${key}:${JSON.stringify(value.get<string[]>())}`);
+      } else if (value.is<bool[]>()) {
+        segments.push(`${key}:${JSON.stringify(value.get<bool[]>())}`);
+      } else if (value.is<i32[]>()) {
+        segments.push(`${key}:${JSON.stringify(value.get<i32[]>())}`);
+      } else if (value.is<u32[]>()) {
+        segments.push(`${key}:${JSON.stringify(value.get<u32[]>())}`);
+      } else if (value.is<i64[]>()) {
+        segments.push(`${key}:${JSON.stringify(value.get<i64[]>())}`);
+      } else if (value.is<f32[]>()) {
+        segments.push(`${key}:${JSON.stringify(value.get<f32[]>())}`);
+      } else if (value.is<f64[]>()) {
+        segments.push(`${key}:${JSON.stringify(value.get<f64[]>())}`);
+      } else if (value.is<i8[]>()) {
+        segments.push(`${key}:${JSON.stringify(value.get<i8[]>())}`);
+      } else if (value.is<u8[]>()) {
+        segments.push(`${key}:${JSON.stringify(value.get<u8[]>())}`);
+      } else if (value.is<i16[]>()) {
+        segments.push(`${key}:${JSON.stringify(value.get<i16[]>())}`);
+      } else if (value.is<u16[]>()) {
+        segments.push(`${key}:${JSON.stringify(value.get<u16[]>())}`);
+      } else {
+        throw new Error(
+          "Query parameters must be simple types, or arrays of simple types.",
+        );
+      }
+    }
+
+    return `{${segments.join(",")}}`;
+  }
+}

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
+        "as-variant": "^0.4.1",
         "json-as": "^0.8.1",
         "xid-ts": "^1.1.0"
       },

--- a/src/package.json
+++ b/src/package.json
@@ -14,6 +14,7 @@
     "lint:fix": "eslint --ext .ts --fix ."
   },
   "dependencies": {
+    "as-variant": "^0.4.1",
     "json-as": "^0.8.1",
     "xid-ts": "^1.1.0"
   },


### PR DESCRIPTION
Fixes HYP-869

Breaking change - Instead of a `Map<string, string>`, pass a `QueryParameters` object instead.  For example:

```ts
const parameters = new QueryParameters();
parameters.set("$firstName", firstName);
parameters.set("$lastName", lastName);

const response = dql.query<PeopleData>(query, parameters);
```

Parameter values don't have to be strings, but they do have to be simple types (`bool`, `string`, `i32`, etc.), or arrays of simple types.