### PR TITLE
Use local path to library in example

### DIFF
--- a/.github/workflows/ci-as-build.yml
+++ b/.github/workflows/ci-as-build.yml
@@ -39,14 +39,6 @@ jobs:
         with:
           node-version: ">=20"
       - name: Install dependencies
-        working-directory: src/
         run: npm install
-      - name: Establish link
-        working-directory: src/
-        run: npm link
-      - name: Install additional dependencies
-        run: npm install
-      - name: Use linked source
-        run: npm link @hypermode/functions-as
       - name: Build project
         run: npm run build

--- a/.github/workflows/ci-as-build.yml
+++ b/.github/workflows/ci-as-build.yml
@@ -39,6 +39,9 @@ jobs:
         with:
           node-version: ">=20"
       - name: Install dependencies
+        working-directory: src/
+        run: npm install
+      - name: Install additional dependencies
         run: npm install
       - name: Build project
         run: npm run build

--- a/.github/workflows/ci-as-lint.yml
+++ b/.github/workflows/ci-as-lint.yml
@@ -39,6 +39,10 @@ jobs:
         with:
           node-version: ">=20"
       - name: Install dependencies
+        working-directory: src/
+        run: npm install
+      - name: Install additional dependencies
+        if: ${{ matrix.dir != 'src/' }}
         run: npm install
       - name: Validate code is formatted
         run: npm run pretty:check

--- a/.github/workflows/ci-as-lint.yml
+++ b/.github/workflows/ci-as-lint.yml
@@ -39,18 +39,7 @@ jobs:
         with:
           node-version: ">=20"
       - name: Install dependencies
-        working-directory: src/
         run: npm install
-      - name: Establish link
-        if: ${{ matrix.dir != 'src/' }}
-        working-directory: src/
-        run: npm link
-      - name: Install additional dependencies
-        if: ${{ matrix.dir != 'src/' }}
-        run: npm install
-      - name: Use linked source
-        if: ${{ matrix.dir != 'src/' }}
-        run: npm link @hypermode/functions-as
       - name: Validate code is formatted
         run: npm run pretty:check
       - name: Valid code is linted

--- a/examples/hmplugin1/package-lock.json
+++ b/examples/hmplugin1/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@hypermode/functions-as": "^0.4.0",
+        "@hypermode/functions-as": "../../src",
         "json-as": "^0.8.1"
       },
       "devDependencies": {
@@ -21,6 +21,25 @@
         "eslint": "^8.57.0",
         "prettier": "^3.2.5",
         "run-script-os": "^1.1.6",
+        "visitor-as": "^0.11.4"
+      }
+    },
+    "../../src": {
+      "version": "0.4.0",
+      "license": "MIT",
+      "dependencies": {
+        "as-variant": "^0.4.1",
+        "json-as": "^0.8.1",
+        "xid-ts": "^1.1.0"
+      },
+      "devDependencies": {
+        "@types/node": "^20.12.3",
+        "@typescript-eslint/eslint-plugin": "^7.5.0",
+        "@typescript-eslint/parser": "^7.5.0",
+        "assemblyscript": "^0.27.26",
+        "assemblyscript-prettier": "^3.0.1",
+        "eslint": "^8.57.0",
+        "prettier": "^3.2.5",
         "visitor-as": "^0.11.4"
       }
     },
@@ -177,23 +196,8 @@
       "dev": true
     },
     "node_modules/@hypermode/functions-as": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@hypermode/functions-as/-/functions-as-0.4.0.tgz",
-      "integrity": "sha512-z5yDq3qFttZ2A5dJJLnTsxx+wAqpJlz+b4EYVQW0N+bi+I8/j2CqhxxPRxncygHRkUqDEk8T+7BkhSJue9mocA==",
-      "dependencies": {
-        "json-as": "^0.7.3",
-        "xid-ts": "^1.1.0"
-      }
-    },
-    "node_modules/@hypermode/functions-as/node_modules/json-as": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/json-as/-/json-as-0.7.3.tgz",
-      "integrity": "sha512-tTM4Ehp0k6h6BIpCuMvItQxVq0SZQ5nGPrYlzwSJ9xquu2bKYPshJKKcWQsH2pGTcMe24bKUGHi0I3ZqhODQOw==",
-      "dependencies": {
-        "as-string-sink": "^0.5.3",
-        "as-variant": "^0.4.1",
-        "as-virtual": "^0.1.9"
-      }
+      "resolved": "../../src",
+      "link": true
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -1795,14 +1799,6 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true
-    },
-    "node_modules/xid-ts": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/xid-ts/-/xid-ts-1.1.0.tgz",
-      "integrity": "sha512-MVMypK+qLyDscU/gt1Y7vR8puZ+C6OL1NxNpumKUlziifoVHjJxwLAi7gRWbKIlEU/LTwrPLnnqnw0SAisVkqQ==",
-      "engines": {
-        "node": ">=18.0.0"
-      }
     },
     "node_modules/yallist": {
       "version": "4.0.0",

--- a/examples/hmplugin1/package.json
+++ b/examples/hmplugin1/package.json
@@ -16,7 +16,7 @@
     "lint:fix": "eslint --ext .ts --fix ."
   },
   "dependencies": {
-    "@hypermode/functions-as": "^0.4.0",
+    "@hypermode/functions-as": "../../src",
     "json-as": "^0.8.1"
   },
   "devDependencies": {


### PR DESCRIPTION
This lets `npm install` just work, without having to use `npm link`, for the example plugin.

The downside is that the example can't be copy/paste by itself without updating the `package.json` file to use a published version of the library.  But that should be ok for now.

