### PR TITLE
Export type information in metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - **(BREAKING)** Support query parameters of different types. [#40](https://github.com/gohypermode/functions-as/pull/40)
 - Further improvements to compiler output. [#41](https://github.com/gohypermode/functions-as/pull/41)
 - Example project now uses a local path to the source library. [#42](https://github.com/gohypermode/functions-as/pull/42)
+- Capture custom data type definitions in the metadata. [#42](https://github.com/gohypermode/functions-as/pull/44)
 
 # 2024-03-22 - Version 0.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - **(BREAKING)** Support query parameters of different types. [#40](https://github.com/gohypermode/functions-as/pull/40)
 - Further improvements to compiler output. [#41](https://github.com/gohypermode/functions-as/pull/41)
 - Example project now uses a local path to the source library. [#42](https://github.com/gohypermode/functions-as/pull/42)
-- Capture custom data type definitions in the metadata. [#42](https://github.com/gohypermode/functions-as/pull/44)
+- Capture custom data type definitions in the metadata. [#44](https://github.com/gohypermode/functions-as/pull/44)
 
 # 2024-03-22 - Version 0.4.0
 

--- a/examples/hmplugin1/assembly/index.ts
+++ b/examples/hmplugin1/assembly/index.ts
@@ -15,14 +15,14 @@ export function getFullName(firstName: string, lastName: string): string {
   return `${firstName} ${lastName}`;
 }
 
-export function getPeople(): string {
+export function getPeople(): Person[] {
   const people = [
     <Person>{ firstName: "Bob", lastName: "Smith" },
     <Person>{ firstName: "Alice", lastName: "Jones" },
   ];
 
   people.forEach((p) => p.updateFullName());
-  return JSON.stringify(people);
+  return people;
 }
 
 export function queryPeople1(): string {
@@ -133,7 +133,7 @@ function getPersonCount(): i32 {
   return response.data.aggregatePerson.count;
 }
 
-export function getRandomPerson(): string {
+export function getRandomPerson(): Person {
   const count = getPersonCount();
   const offset = <u32>Math.floor(Math.random() * count);
   const statement = `
@@ -148,7 +148,7 @@ export function getRandomPerson(): string {
   `;
 
   const results = graphql.execute<PeopleData>(statement);
-  return JSON.stringify(results.data.people[0]);
+  return results.data.people[0];
 }
 
 export function testClassifier(modelId: string, text: string): string {

--- a/src/transform/src/index.ts
+++ b/src/transform/src/index.ts
@@ -2,14 +2,16 @@ import { Transform } from "assemblyscript/dist/transform.js";
 import { createWriteStream } from "fs";
 import { HypermodeMetadata } from "./metadata.js";
 import { Extractor } from "./extractor.js";
+import binaryen from "assemblyscript/lib/binaryen.js";
 
 export default class HypermodeTransform extends Transform {
-  async afterCompile(module) {
+  async afterCompile(module: binaryen.Module) {
     const extractor = new Extractor(this, module);
-    const functions = await extractor.getExportedFunctions();
+    const info = await extractor.getProgramInfo();
 
     const m = HypermodeMetadata.generate();
-    m.addFunctions(functions);
+    m.addFunctions(info.functions);
+    m.addTypes(info.types);
     m.writeToModule(module);
 
     // Write to stdout

--- a/src/transform/src/metadata.ts
+++ b/src/transform/src/metadata.ts
@@ -7,7 +7,7 @@ import binaryen from "assemblyscript/lib/binaryen.js";
 import { Colors } from "assemblyscript/util/terminal.js";
 import { WriteStream as FSWriteStream } from "fs";
 import { WriteStream as TTYWriteStream } from "tty";
-import { FunctionSignature } from "./types.js";
+import { FunctionSignature, TypeDefinition } from "./types.js";
 import writeLogo from "./logo.js";
 
 export class HypermodeMetadata {
@@ -18,6 +18,7 @@ export class HypermodeMetadata {
   gitRepo?: string;
   gitCommit?: string;
   functions: FunctionSignature[] = [];
+  types: TypeDefinition[] = [];
 
   static generate(): HypermodeMetadata {
     const m = new HypermodeMetadata();
@@ -37,6 +38,10 @@ export class HypermodeMetadata {
 
   addFunctions(functions: FunctionSignature[]) {
     this.functions.push(...functions);
+  }
+
+  addTypes(types: TypeDefinition[]) {
+    this.types.push(...types);
   }
 
   writeToModule(module: binaryen.Module) {
@@ -111,6 +116,12 @@ export class HypermodeMetadata {
     writeHeader("Hypermode Functions:");
     this.functions.forEach((f) => writeItem(f.toString()));
     stream.write("\n");
+
+    if (this.types.length > 0) {
+      writeHeader("Custom Data Types:");
+      this.types.forEach((t) => writeItem(t.toString()));
+      stream.write("\n");
+    }
   }
 }
 

--- a/src/transform/src/types.ts
+++ b/src/transform/src/types.ts
@@ -1,7 +1,7 @@
 export class FunctionSignature {
   constructor(
     public name: string,
-    public parameters: Parameter[],
+    public parameters: NameTypePair[],
     public returnType: string,
   ) {}
 
@@ -13,7 +13,24 @@ export class FunctionSignature {
   }
 }
 
-interface Parameter {
+export class TypeDefinition {
+  constructor(
+    public name: string,
+    public fields?: NameTypePair[],
+  ) {}
+
+  toString() {
+    // If there are no fields, just return the name. It will be interpreted as a scalar type.
+    if (!this.fields || this.fields.length === 0) {
+      return this.name;
+    }
+
+    const fields = this.fields.map((f) => `${f.name}: ${f.type}`).join(", ");
+    return `${this.name} { ${fields} }`;
+  }
+}
+
+interface NameTypePair {
   name: string;
   type: string;
 }

--- a/src/transform/src/visitor.ts
+++ b/src/transform/src/visitor.ts
@@ -1,21 +1,22 @@
-import { FunctionSignature } from "./types.js";
+import { FunctionSignature, TypeDefinition } from "./types.js";
 import { BaseVisitor, utils } from "visitor-as";
 import {
+  ClassDeclaration,
+  FieldDeclaration,
   FunctionDeclaration,
+  FunctionTypeNode,
+  NamedTypeNode,
+  NodeKind,
   TypeNode,
 } from "assemblyscript/dist/assemblyscript.js";
 
 export class HypermodeVisitor extends BaseVisitor {
   functions = new Map<string, FunctionSignature>();
+  classes = new Map<string, TypeDefinition>();
+  typesUsed = new Map<string, string[]>();
 
   visitFunctionDeclaration(node: FunctionDeclaration): void {
     const internalPath = node.range.source.internalPath;
-
-    // skip library functions
-    if (internalPath.startsWith("~")) {
-      return;
-    }
-
     const name = node.name.text;
     const path = `${internalPath}/${name}`;
 
@@ -25,12 +26,86 @@ export class HypermodeVisitor extends BaseVisitor {
       type: getTypeName(p.type),
     }));
 
-    const returnType = getTypeName(signature.returnType);
+    const returnTypeName = getTypeName(signature.returnType);
 
-    const f = new FunctionSignature(name, parameters, returnType);
+    const f = new FunctionSignature(name, parameters, returnTypeName);
     this.functions.set(path, f);
+
+    this.setUsedTypes(signature);
+  }
+
+  visitClassDeclaration(node: ClassDeclaration): void {
+    const internalPath = node.range.source.internalPath;
+    const name = node.name.text;
+    const path = `${internalPath}/${name}`;
+
+    const fields = node.members
+      .map((m) => {
+        if (m.kind === NodeKind.FieldDeclaration) {
+          const field = m as FieldDeclaration;
+          const typeName = getTypeName(field.type);
+          const typesUsed = this.resolveTypeNames(field.type);
+          this.typesUsed.set(typeName, typesUsed);
+          return {
+            name: field.name.text,
+            type: typeName,
+          };
+        }
+      })
+      .filter((f) => f !== undefined);
+
+    const t = new TypeDefinition(name, fields);
+    this.classes.set(path, t);
+  }
+
+  private setUsedTypes(signature: FunctionTypeNode) {
+    signature.parameters
+      .map((p) => p.type)
+      .concat(signature.returnType)
+      .forEach((t) => {
+        const typeName = getTypeName(t);
+        const typesUsed = this.resolveTypeNames(t);
+        this.typesUsed.set(typeName, typesUsed);
+      });
+  }
+
+  private resolveTypeNames(tn: TypeNode): string[] {
+    if (tn.kind !== NodeKind.NamedType) {
+      return [];
+    }
+
+    const node = tn as NamedTypeNode;
+    const name = node.name.identifier.text;
+
+    const results = [];
+    if (!handledTypes.has(name)) {
+      results.push(name);
+    }
+    node.typeArguments.forEach((t) =>
+      results.push(...this.resolveTypeNames(t)),
+    );
+
+    return Array.from(new Set(results));
   }
 }
+
+const handledTypes = new Set([
+  "string",
+  "bool",
+  "i64",
+  "i32",
+  "i16",
+  "i8",
+  "u64",
+  "u32",
+  "u16",
+  "u8",
+  "f64",
+  "f32",
+  "Array",
+  "Map",
+  "Date",
+]);
 
 const arrayRegex = /^Array<(.+)>/;
 function getTypeName(t: TypeNode): string {


### PR DESCRIPTION
Exports type information in the metadata, if it's used in the function signature.  This will be used to support custom data type responses in the GraphQL schema generation.

```
Hypermode Functions:
  getPeople(): Person[]
  getRandomPerson(): Person

Custom Data Types:
  Person { id: string | null, firstName: string, lastName: string, fullName: string | null }
```

Also fixed a bug where array and map types were being captured incorrectly, as either just `Array` or `Map` rather than `string[]` or `Map<string, i32>` (etc.)

Completes HYP-924

NOTE:

- No runtime support yet.  Coming soon.
- The two example functions in `hmplugin1` that return `People` objects will be temporarily broken until the Runtime support is improved.
- There's a known issue with potential naming conflicts if a custom type is defined more than once with the same name (ie. in different `.ts` files).  I'll fix that later.