### PR TITLE
Include field offsets in metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - **(BREAKING)** Support query parameters of different types. [#40](https://github.com/gohypermode/functions-as/pull/40)
 - Further improvements to compiler output. [#41](https://github.com/gohypermode/functions-as/pull/41)
 - Example project now uses a local path to the source library. [#42](https://github.com/gohypermode/functions-as/pull/42)
-- Capture custom data type definitions in the metadata. [#44](https://github.com/gohypermode/functions-as/pull/44) [#52](https://github.com/gohypermode/functions-as/pull/52)
+- Capture custom data type definitions in the metadata. [#44](https://github.com/gohypermode/functions-as/pull/44) [#52](https://github.com/gohypermode/functions-as/pull/52) [#53](https://github.com/gohypermode/functions-as/pull/53)
 - Improve build scripts [#46](https://github.com/gohypermode/functions-as/pull/46) [#51](https://github.com/gohypermode/functions-as/pull/51)
 
 # 2024-03-22 - Version 0.4.0

--- a/src/transform/src/extractor.ts
+++ b/src/transform/src/extractor.ts
@@ -139,6 +139,7 @@ export class Extractor {
       .map((f) => ({
         name: f.name,
         type: getTypeInfo(f.type),
+        offset: f.memoryOffset,
       }));
   }
 

--- a/src/transform/src/types.ts
+++ b/src/transform/src/types.ts
@@ -6,7 +6,7 @@ export class ProgramInfo {
 export class FunctionSignature {
   constructor(
     public name: string,
-    public parameters: NameTypePair[],
+    public parameters: Parameter[],
     public returnType: TypeInfo,
   ) {}
 
@@ -24,7 +24,7 @@ export class TypeDefinition implements TypeInfo {
     public size: number,
     public path: string,
     public name: string,
-    public fields?: NameTypePair[],
+    public fields?: Field[],
   ) {}
 
   toString() {
@@ -53,9 +53,15 @@ export interface TypeInfo {
   path: string;
 }
 
-export interface NameTypePair {
+interface Parameter {
   name: string;
   type: TypeInfo;
+}
+
+interface Field {
+  name: string;
+  type: TypeInfo;
+  offset: number;
 }
 
 export const typeMap = new Map<string, string>([


### PR DESCRIPTION
I thought we would be able to calculate field offsets based on the size of the fields, but AssemblyScript does some memory alignment tricks and it turns out to be much easier to embed the offset than to try to re-created their algorithms.