### PR TITLE
Add env var to debug metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Example project now uses a local path to the source library. [#42](https://github.com/gohypermode/functions-as/pull/42)
 - Capture custom data type definitions in the metadata. [#44](https://github.com/gohypermode/functions-as/pull/44) [#52](https://github.com/gohypermode/functions-as/pull/52) [#53](https://github.com/gohypermode/functions-as/pull/53)
 - Improve build scripts [#46](https://github.com/gohypermode/functions-as/pull/46) [#51](https://github.com/gohypermode/functions-as/pull/51)
+- Add environment variable to debug metadata [#54](https://github.com/gohypermode/functions-as/pull/54)
 
 # 2024-03-22 - Version 0.4.0
 

--- a/src/transform/src/metadata.ts
+++ b/src/transform/src/metadata.ts
@@ -123,6 +123,12 @@ export class HypermodeMetadata {
       types.forEach((t) => writeItem(t.toString()));
       stream.write("\n");
     }
+
+    if (process.env.HYPERMODE_DEBUG) {
+      writeHeader("Metadata JSON:");
+      stream.write(JSON.stringify(this, undefined, 2));
+      stream.write("\n\n");
+    }
   }
 }
 


### PR DESCRIPTION
I find myself doing this manually a lot, so it should probably be built-in.

Set `HYPERMODE_DEBUG=true` when building to dump the full metadata JSON - the same exact data that is embedded as `hypermode_meta` in the wasm.