### PR TITLE
Fix threshold logic bug in `inference.classifyText`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+# UNRELEASED
+
+- Fixed threshold logic bug in `inference.classifyText` [#76](https://github.com/gohypermode/functions-as/pull/76)
+
 # 2024-04-25 - Version 0.6.1
 
 - Fixed compilation transform error when there are no host functions used. [#69](https://github.com/gohypermode/functions-as/pull/69)

--- a/src/assembly/inference.ts
+++ b/src/assembly/inference.ts
@@ -28,7 +28,7 @@ export abstract class inference {
 
     const keys = labels.keys();
     let max = labels.get(keys[0]);
-    let result = "";
+    let result = keys[0];
     for (let i = 1; i < keys.length; i++) {
       const key = keys[i];
       const value = labels.get(key);


### PR DESCRIPTION
Fixes HYP-1116