### PR TITLE
Add typescript as a dev dependency

### DIFF
--- a/examples/classification/package-lock.json
+++ b/examples/classification/package-lock.json
@@ -20,6 +20,7 @@
         "assemblyscript-prettier": "^3.0.1",
         "eslint": "^8.57.0",
         "prettier": "^3.2.5",
+        "typescript": "^5.4.5",
         "visitor-as": "^0.11.4"
       }
     },
@@ -41,6 +42,7 @@
         "eslint": "^8.57.0",
         "prettier": "^3.2.5",
         "semver": "^7.6.0",
+        "typescript": "^5.4.5",
         "visitor-as": "^0.11.4"
       }
     },
@@ -1739,7 +1741,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
       "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
       "dev": true,
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/examples/classification/package.json
+++ b/examples/classification/package.json
@@ -25,6 +25,7 @@
     "assemblyscript-prettier": "^3.0.1",
     "eslint": "^8.57.0",
     "prettier": "^3.2.5",
+    "typescript": "^5.4.5",
     "visitor-as": "^0.11.4"
   },
   "overrides": {

--- a/examples/embedding/package-lock.json
+++ b/examples/embedding/package-lock.json
@@ -20,6 +20,7 @@
         "assemblyscript-prettier": "^3.0.1",
         "eslint": "^8.57.0",
         "prettier": "^3.2.5",
+        "typescript": "^5.4.5",
         "visitor-as": "^0.11.4"
       }
     },
@@ -41,6 +42,7 @@
         "eslint": "^8.57.0",
         "prettier": "^3.2.5",
         "semver": "^7.6.0",
+        "typescript": "^5.4.5",
         "visitor-as": "^0.11.4"
       }
     },
@@ -1739,7 +1741,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
       "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
       "dev": true,
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/examples/embedding/package.json
+++ b/examples/embedding/package.json
@@ -25,6 +25,7 @@
     "assemblyscript-prettier": "^3.0.1",
     "eslint": "^8.57.0",
     "prettier": "^3.2.5",
+    "typescript": "^5.4.5",
     "visitor-as": "^0.11.4"
   },
   "overrides": {

--- a/examples/graphql/package-lock.json
+++ b/examples/graphql/package-lock.json
@@ -20,6 +20,7 @@
         "assemblyscript-prettier": "^3.0.1",
         "eslint": "^8.57.0",
         "prettier": "^3.2.5",
+        "typescript": "^5.4.5",
         "visitor-as": "^0.11.4"
       }
     },
@@ -41,6 +42,7 @@
         "eslint": "^8.57.0",
         "prettier": "^3.2.5",
         "semver": "^7.6.0",
+        "typescript": "^5.4.5",
         "visitor-as": "^0.11.4"
       }
     },
@@ -1739,7 +1741,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
       "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
       "dev": true,
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/examples/graphql/package.json
+++ b/examples/graphql/package.json
@@ -25,6 +25,7 @@
     "assemblyscript-prettier": "^3.0.1",
     "eslint": "^8.57.0",
     "prettier": "^3.2.5",
+    "typescript": "^5.4.5",
     "visitor-as": "^0.11.4"
   },
   "overrides": {

--- a/examples/simple/package-lock.json
+++ b/examples/simple/package-lock.json
@@ -20,6 +20,7 @@
         "assemblyscript-prettier": "^3.0.1",
         "eslint": "^8.57.0",
         "prettier": "^3.2.5",
+        "typescript": "^5.4.5",
         "visitor-as": "^0.11.4"
       }
     },
@@ -41,6 +42,7 @@
         "eslint": "^8.57.0",
         "prettier": "^3.2.5",
         "semver": "^7.6.0",
+        "typescript": "^5.4.5",
         "visitor-as": "^0.11.4"
       }
     },
@@ -1589,7 +1591,6 @@
       "version": "5.4.5",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3213,9 +3214,9 @@
     },
     "node_modules/typescript": {
       "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
+      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
       "dev": true,
-      "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/examples/simple/package.json
+++ b/examples/simple/package.json
@@ -25,6 +25,7 @@
     "assemblyscript-prettier": "^3.0.1",
     "eslint": "^8.57.0",
     "prettier": "^3.2.5",
+    "typescript": "^5.4.5",
     "visitor-as": "^0.11.4"
   },
   "overrides": {

--- a/examples/textgeneration/package-lock.json
+++ b/examples/textgeneration/package-lock.json
@@ -20,6 +20,7 @@
         "assemblyscript-prettier": "^3.0.1",
         "eslint": "^8.57.0",
         "prettier": "^3.2.5",
+        "typescript": "^5.4.5",
         "visitor-as": "^0.11.4"
       }
     },
@@ -41,6 +42,7 @@
         "eslint": "^8.57.0",
         "prettier": "^3.2.5",
         "semver": "^7.6.0",
+        "typescript": "^5.4.5",
         "visitor-as": "^0.11.4"
       }
     },
@@ -1739,7 +1741,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
       "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
       "dev": true,
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/examples/textgeneration/package.json
+++ b/examples/textgeneration/package.json
@@ -25,6 +25,7 @@
     "assemblyscript-prettier": "^3.0.1",
     "eslint": "^8.57.0",
     "prettier": "^3.2.5",
+    "typescript": "^5.4.5",
     "visitor-as": "^0.11.4"
   },
   "overrides": {

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -22,6 +22,7 @@
         "eslint": "^8.57.0",
         "prettier": "^3.2.5",
         "semver": "^7.6.0",
+        "typescript": "^5.4.5",
         "visitor-as": "^0.11.4"
       }
     },
@@ -1715,7 +1716,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
       "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
       "dev": true,
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/src/package.json
+++ b/src/package.json
@@ -29,6 +29,7 @@
     "eslint": "^8.57.0",
     "prettier": "^3.2.5",
     "semver": "^7.6.0",
+    "typescript": "^5.4.5",
     "visitor-as": "^0.11.4"
   },
   "overrides": {


### PR DESCRIPTION
We had been assuming a globally-installed Typescript compiler, which may or may not be the case for the user.