### PR TITLE
Align `hypermode.json` examples to changes in manifest schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 # UNRELEASED
 
 - Fixed threshold logic bug in `inference.classifyText` [#76](https://github.com/gohypermode/functions-as/pull/76)
+- Align `hypermode.json` examples to changes in manifest schema [#79](https://github.com/gohypermode/functions-as/pull/79) [#80](https://github.com/gohypermode/functions-as/pull/80)
 
 # 2024-04-25 - Version 0.6.1
 

--- a/examples/classification/assembly/index.ts
+++ b/examples/classification/assembly/index.ts
@@ -2,7 +2,7 @@ import { inference } from "@hypermode/functions-as";
 import { JSON } from "json-as";
 
 // This model name should match one defined in the hypermode.json manifest file.
-const modelName: string = "my_custom_classifier";
+const modelName: string = "my-custom-classifier";
 
 // This function takes input text and a probability threshold, and returns the
 // classification label determined by the model.

--- a/examples/classification/hypermode.json
+++ b/examples/classification/hypermode.json
@@ -2,23 +2,23 @@
   "$schema": "https://manifest.hypermode.com/hypermode.json",
   "models": [
     {
-      "name": "my_classifier",
+      "name": "my-classifier",
       "task": "classification",
       "sourceModel": "distilbert/distilbert-base-uncased",
       "host": "hypermode",
       "provider": "hugging-face"
     },
     {
-      "name": "my_custom_classifier",
+      "name": "my-custom-classifier",
       "task": "classification",
       "sourceModel": "distilbert-base-uncased",
-      "host": "aws_classifier",
+      "host": "aws-classifier",
       "provider": "custom"
     }
   ],
   "hosts": [
     {
-      "name": "aws_classifier",
+      "name": "aws-classifier",
       "endpoint": "https://nerpndlnl6.execute-api.us-east-1.amazonaws.com/dev/classifier",
       "authHeader": "x-api-key"
     }

--- a/examples/embedding/assembly/index.ts
+++ b/examples/embedding/assembly/index.ts
@@ -2,7 +2,7 @@ import { inference } from "@hypermode/functions-as";
 import { JSON } from "json-as";
 
 // This model name should match one defined in the hypermode.json manifest file.
-const modelName: string = "my_custom_embedding";
+const modelName: string = "my-custom-embedding";
 
 // This function takes input text and returns the vector embedding for that text.
 export function testEmbedding(text: string): f64[] {

--- a/examples/embedding/hypermode.json
+++ b/examples/embedding/hypermode.json
@@ -2,23 +2,23 @@
   "$schema": "https://manifest.hypermode.com/hypermode.json",
   "models": [
     {
-      "name": "my_embedding",
+      "name": "my-embedding",
       "task": "embedding",
       "sourceModel": "sentence-transformers/all-MiniLM-L6-v2",
       "host": "hypermode",
       "provider": "hugging-face"
     },
     {
-      "name": "my_custom_embedding",
+      "name": "my-custom-embedding",
       "task": "embedding",
       "sourceModel": "all-MiniLM-L6-v2",
-      "host": "aws_embedding",
+      "host": "aws-embedding",
       "provider": "custom"
     }
   ],
   "hosts": [
     {
-      "name": "aws_embedding",
+      "name": "aws-embedding",
       "endpoint": "https://2f050wcjqd.execute-api.us-east-1.amazonaws.com/dev/embedding",
       "authHeader": "x-api-key"
     }

--- a/examples/textgeneration/assembly/index.ts
+++ b/examples/textgeneration/assembly/index.ts
@@ -2,7 +2,7 @@ import { inference } from "@hypermode/functions-as";
 import { Product, sampleProduct } from "./product";
 
 // This model name should match the one defined in the hypermode.json manifest file.
-const modelName: string = "text_generator";
+const modelName: string = "text-generator";
 
 // This function generates some text based on the instruction and prompt provided.
 export function generateText(instruction: string, prompt: string): string {


### PR DESCRIPTION
Underscores are now disallowed in model and host names.  Use hyphens instead.