### PR TITLE
Remove extraneous JSON import

### DIFF
--- a/examples/graphql/assembly/classes.ts
+++ b/examples/graphql/assembly/classes.ts
@@ -1,8 +1,4 @@
-// For now, this import is required when we use @json, even if we're not calling
-// methods on the JSON class.  It will be fixed in the future.
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-import { JSON } from "json-as";
-
+// These classes are used by the example functions in the index.ts file.
 
 @json
 export class Person {

--- a/examples/http/assembly/classes.ts
+++ b/examples/http/assembly/classes.ts
@@ -1,8 +1,3 @@
-// For now, this import is required when we use @json, even if we're not calling
-// methods on the JSON class.  It will be fixed in the future.
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-import { JSON } from "json-as";
-
 // These classes are used by the example functions in the index.ts file.
 
 @json

--- a/examples/textgeneration/assembly/product.ts
+++ b/examples/textgeneration/assembly/product.ts
@@ -1,8 +1,3 @@
-// For now, this import is required when we use @json, even if we're not calling
-// methods on the JSON class.  It will be fixed in the future.
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-import { JSON } from "json-as";
-
 // The Product class and the sample product will be used in the some of the examples.
 // Note that the class must be decorated with @json so that it can be serialized
 // and deserialized properly when interacting with OpenAI.


### PR DESCRIPTION
The issue with requiring an extraneous JSON import was resolved in json-as 0.8.3.  We can clean up our examples.