### PR TITLE
Remove `@embedder` decorator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## Unreleased
+
+- Remove `@embedder` decorator [#112](https://github.com/hypermodeAI/functions-as/pull/112)
+
 ## 2024-06-21 - Version 0.9.0
 
 _Note: Requires Hypermode Runtime v0.9.0 or newer_

--- a/src/transform/src/extractor.ts
+++ b/src/transform/src/extractor.ts
@@ -1,3 +1,4 @@
+import { Transform } from "assemblyscript/dist/transform.js";
 import binaryen from "assemblyscript/lib/binaryen.js";
 import {
   Class,
@@ -15,31 +16,20 @@ import {
   TypeInfo,
   typeMap,
 } from "./types.js";
-import HypermodeTransform from "./index.js";
 
 export class Extractor {
   binaryen: typeof binaryen;
   module: binaryen.Module;
   program: Program;
-  transform: HypermodeTransform;
 
-  constructor(transform: HypermodeTransform, module: binaryen.Module) {
+  constructor(transform: Transform, module: binaryen.Module) {
     this.program = transform.program;
     this.binaryen = transform.binaryen;
     this.module = module;
-    this.transform = transform;
   }
 
   getProgramInfo(): ProgramInfo {
     const functions = this.getExportedFunctions()
-      .filter((e) => {
-        return !this.transform.embedders.includes(e.name);
-      })
-      .map((e) => this.convertToFunctionSignature(e))
-      .sort((a, b) => a.name.localeCompare(b.name));
-
-    const embedders = this.getExportedFunctions()
-      .filter((e) => this.transform.embedders.includes(e.name))
       .map((e) => this.convertToFunctionSignature(e))
       .sort((a, b) => a.name.localeCompare(b.name));
 
@@ -86,7 +76,7 @@ export class Extractor {
       (a.name + a.path).localeCompare(b.name + b.path),
     );
 
-    return { functions, types, embedders };
+    return { functions, types };
   }
 
   private expandDependentTypes(

--- a/src/transform/src/index.ts
+++ b/src/transform/src/index.ts
@@ -3,42 +3,14 @@ import { createWriteStream } from "fs";
 import { HypermodeMetadata } from "./metadata.js";
 import { Extractor } from "./extractor.js";
 import binaryen from "assemblyscript/lib/binaryen.js";
-import {
-  Parser,
-  FunctionDeclaration,
-  IdentifierExpression,
-  NodeKind,
-  CommonFlags,
-} from "assemblyscript/dist/assemblyscript.js";
-import { isStdlib } from "./utils.js";
 
 export default class HypermodeTransform extends Transform {
-  public embedders: string[] | null = null;
-  afterParse(parser: Parser): void | Promise<void> {
-    const exportedFunctions: FunctionDeclaration[] = [];
-    for (const source of parser.sources) {
-      if (isStdlib(source)) continue;
-      exportedFunctions.push(
-        ...(source.statements.filter(
-          (e) =>
-            e.kind == NodeKind.FunctionDeclaration &&
-            (<FunctionDeclaration>e).flags == CommonFlags.Export &&
-            (<FunctionDeclaration>e).decorators?.find(
-              (v) => (<IdentifierExpression>v.name).text == "embedder",
-            ),
-        ) as FunctionDeclaration[]),
-      );
-    }
-
-    this.embedders = exportedFunctions.map((e) => e.name.text);
-  }
   afterCompile(module: binaryen.Module) {
     const extractor = new Extractor(this, module);
     const info = extractor.getProgramInfo();
 
     const m = HypermodeMetadata.generate();
     m.addFunctions(info.functions);
-    m.addEmbedders(info.embedders);
     m.addTypes(info.types);
     m.writeToModule(module);
 

--- a/src/transform/src/metadata.ts
+++ b/src/transform/src/metadata.ts
@@ -18,7 +18,6 @@ export class HypermodeMetadata {
   gitRepo?: string;
   gitCommit?: string;
   functions: FunctionSignature[] = [];
-  embedders: FunctionSignature[] = [];
   types: TypeDefinition[] = [];
 
   static generate(): HypermodeMetadata {
@@ -39,51 +38,6 @@ export class HypermodeMetadata {
 
   addFunctions(functions: FunctionSignature[]) {
     this.functions.push(...functions);
-  }
-
-  addEmbedders(functions: FunctionSignature[]) {
-    for (const func of functions) {
-      if (func.parameters.length != 1)
-        throw new Error(
-          "Expected embedder to have one argument, but found " +
-            (func.parameters.length ? "multiple" : "no") +
-            " arguments!",
-        );
-      const type = func.parameters[0].type.name;
-      const returnType = func.returnType.name;
-
-      if (type != "string" && type != "string[]" && type != "Array<string>") {
-        throw new Error(
-          "Expected embedder to have one argument of type 'string' or 'string[]', but found '" +
-            type +
-            "' instead!",
-        );
-      }
-
-      if (
-        type == "string" &&
-        returnType != "f64[]" &&
-        returnType != "Array<f64>"
-      ) {
-        throw new Error(
-          "Expected return type to be of type 'f64[]', but found '" +
-            returnType +
-            "' instead!",
-        );
-      } else if (
-        (type == "Array<string>" || type == "string[]") &&
-        returnType != "f64[][]" &&
-        returnType != "Array<Array<f64>>"
-      ) {
-        throw new Error(
-          "Expected return type to be of type 'f64[][]', but found '" +
-            returnType +
-            "' instead!",
-        );
-      }
-
-      this.embedders.push(func);
-    }
   }
 
   addTypes(types: TypeDefinition[]) {
@@ -162,12 +116,6 @@ export class HypermodeMetadata {
     writeHeader("Hypermode Functions:");
     this.functions.forEach((f) => writeItem(f.toString()));
     stream.write("\n");
-
-    if (this.embedders.length > 0) {
-      writeHeader("Embedder Functions:");
-      this.embedders.forEach((f) => writeItem(f.toString()));
-      stream.write("\n");
-    }
 
     const types = this.types.filter((t) => !t.isHidden());
     if (types.length > 0) {

--- a/src/transform/src/types.ts
+++ b/src/transform/src/types.ts
@@ -1,7 +1,6 @@
 export class ProgramInfo {
   functions: FunctionSignature[];
   types: TypeDefinition[];
-  embedders: FunctionSignature[];
 }
 
 export class FunctionSignature {

--- a/src/transform/src/utils.ts
+++ b/src/transform/src/utils.ts
@@ -1,8 +1,0 @@
-import { Source } from "assemblyscript/dist/assemblyscript.js";
-
-const isStdlibRegex =
-  /~lib\/(?:array|arraybuffer|atomics|builtins|crypto|console|compat|dataview|date|diagnostics|error|function|iterator|map|math|number|object|process|reference|regexp|set|staticarray|string|symbol|table|typedarray|vector|rt\/?|bindings\/|shared\/typeinfo)|util\/|uri|polyfills|memory/;
-
-export function isStdlib(source: Source) {
-  return isStdlibRegex.test(source.internalPath);
-}


### PR DESCRIPTION
In #104  we added the `@embedder` decorator - but didn't use it.

Nothing wrong with that implementation, but after reconsideration of the use case, we decided to not use at all.