### PR TITLE
Make plugin version optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## UNRELEASED
 
 - Add functions and example for accessing PostgreSQL [#119](https://github.com/hypermodeAI/functions-as/pull/119)
+- Make plugin version optional [#133](https://github.com/hypermodeAI/functions-as/pull/133)
 
 ## 2024-07-10 - Version 0.9.4
 

--- a/examples/classification/package-lock.json
+++ b/examples/classification/package-lock.json
@@ -6,7 +6,6 @@
   "packages": {
     "": {
       "name": "classification-example",
-      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@hypermode/functions-as": "../../src",

--- a/examples/classification/package.json
+++ b/examples/classification/package.json
@@ -1,7 +1,6 @@
 {
   "name": "classification-example",
   "private": true,
-  "version": "1.0.0",
   "description": "Hypermode Functions Classification Example",
   "author": "Hypermode, Inc.",
   "license": "MIT",

--- a/examples/collection/package-lock.json
+++ b/examples/collection/package-lock.json
@@ -6,7 +6,6 @@
   "packages": {
     "": {
       "name": "collection-example",
-      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@hypermode/functions-as": "../../src",

--- a/examples/collection/package.json
+++ b/examples/collection/package.json
@@ -1,7 +1,6 @@
 {
   "name": "collection-example",
   "private": true,
-  "version": "1.0.0",
   "description": "Hypermode Functions Collection Example",
   "author": "Hypermode, Inc.",
   "license": "MIT",

--- a/examples/embedding/package-lock.json
+++ b/examples/embedding/package-lock.json
@@ -6,7 +6,6 @@
   "packages": {
     "": {
       "name": "embedding-example",
-      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@hypermode/functions-as": "../../src",

--- a/examples/embedding/package.json
+++ b/examples/embedding/package.json
@@ -1,7 +1,6 @@
 {
   "name": "embedding-example",
   "private": true,
-  "version": "1.0.0",
   "description": "Hypermode Functions Embedding Example",
   "author": "Hypermode, Inc.",
   "license": "MIT",

--- a/examples/graphql/package-lock.json
+++ b/examples/graphql/package-lock.json
@@ -6,7 +6,6 @@
   "packages": {
     "": {
       "name": "graphql-example",
-      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@hypermode/functions-as": "../../src",

--- a/examples/graphql/package.json
+++ b/examples/graphql/package.json
@@ -1,7 +1,6 @@
 {
   "name": "graphql-example",
   "private": true,
-  "version": "1.0.0",
   "description": "Hypermode Functions GraphQL Example",
   "author": "Hypermode, Inc.",
   "license": "MIT",

--- a/examples/http/package-lock.json
+++ b/examples/http/package-lock.json
@@ -6,7 +6,6 @@
   "packages": {
     "": {
       "name": "http-example",
-      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@hypermode/functions-as": "../../src",

--- a/examples/http/package.json
+++ b/examples/http/package.json
@@ -1,7 +1,6 @@
 {
   "name": "http-example",
   "private": true,
-  "version": "1.0.0",
   "description": "Hypermode Functions HTTP Example",
   "author": "Hypermode, Inc.",
   "license": "MIT",

--- a/examples/postgresql/package-lock.json
+++ b/examples/postgresql/package-lock.json
@@ -6,7 +6,6 @@
   "packages": {
     "": {
       "name": "postgresql-example",
-      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@hypermode/functions-as": "../../src",

--- a/examples/postgresql/package.json
+++ b/examples/postgresql/package.json
@@ -1,7 +1,6 @@
 {
   "name": "postgresql-example",
   "private": true,
-  "version": "1.0.0",
   "description": "Hypermode Functions Example using PostgreSQL database",
   "author": "Hypermode, Inc.",
   "license": "MIT",

--- a/examples/simple/package-lock.json
+++ b/examples/simple/package-lock.json
@@ -6,7 +6,6 @@
   "packages": {
     "": {
       "name": "simple-example",
-      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@hypermode/functions-as": "../../src",

--- a/examples/simple/package.json
+++ b/examples/simple/package.json
@@ -1,7 +1,6 @@
 {
   "name": "simple-example",
   "private": true,
-  "version": "1.0.0",
   "description": "Hypermode Functions Simple Example",
   "author": "Hypermode, Inc.",
   "license": "MIT",

--- a/examples/textgeneration/package-lock.json
+++ b/examples/textgeneration/package-lock.json
@@ -6,7 +6,6 @@
   "packages": {
     "": {
       "name": "text-generation-example",
-      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@hypermode/functions-as": "../../src",

--- a/examples/textgeneration/package.json
+++ b/examples/textgeneration/package.json
@@ -1,7 +1,6 @@
 {
   "name": "text-generation-example",
   "private": true,
-  "version": "1.0.0",
   "description": "Hypermode Functions Text Generation Example",
   "author": "Hypermode, Inc.",
   "license": "MIT",

--- a/src/bin/build-plugin.js
+++ b/src/bin/build-plugin.js
@@ -14,8 +14,8 @@ if (!npmPath) {
   process.exit(1);
 }
 
-if (!pkg || !ver) {
-  console.error("A package name and version must be defined in package.json.");
+if (!pkg) {
+  console.error("A package name must be defined in package.json.");
   process.exit(1);
 }
 

--- a/src/transform/src/metadata.ts
+++ b/src/transform/src/metadata.ts
@@ -147,6 +147,16 @@ function getHypermodeInfo(): string {
 function getPluginInfo(): string {
   const pluginName = process.env.npm_package_name;
   const pluginVersion = process.env.npm_package_version;
+
+  if (!pluginName) {
+    throw new Error("Missing name in package.json");
+  }
+
+  if (!pluginVersion) {
+    // versionless plugins are allowed
+    return pluginName;
+  }
+
   return `${pluginName}@${pluginVersion}`;
 }
 

--- a/src/transform/src/metadata.ts
+++ b/src/transform/src/metadata.ts
@@ -14,7 +14,7 @@ export class HypermodeMetadata {
   buildId: string;
   buildTs: string;
   plugin: string;
-  library: string;
+  sdk: string;
   gitRepo?: string;
   gitCommit?: string;
   functions: FunctionSignature[] = [];
@@ -26,7 +26,7 @@ export class HypermodeMetadata {
     m.buildId = new Xid().toString();
     m.buildTs = new Date().toISOString();
     m.plugin = getPluginInfo();
-    m.library = getHypermodeInfo();
+    m.sdk = getSdkInfo();
 
     if (isGitRepo()) {
       m.gitRepo = getGitRepo();
@@ -104,8 +104,8 @@ export class HypermodeMetadata {
 
     writeHeader("Plugin Metadata:");
     writeTable([
-      ["Plugin Name", this.plugin],
-      ["Library", this.library],
+      ["Name", this.plugin],
+      ["SDK", this.sdk],
       ["Build ID", this.buildId],
       ["Build Timestamp", this.buildTs],
       this.gitRepo ? ["Git Repo", this.gitRepo] : undefined,
@@ -132,7 +132,7 @@ export class HypermodeMetadata {
   }
 }
 
-function getHypermodeInfo(): string {
+function getSdkInfo(): string {
   const filePath = path.join(
     path.dirname(fileURLToPath(import.meta.url)),
     "..",
@@ -141,7 +141,7 @@ function getHypermodeInfo(): string {
   );
   const json = readFileSync(filePath).toString();
   const lib = JSON.parse(json);
-  return `${lib.name}@${lib.version}`;
+  return `${lib.name.split("/")[1]}@${lib.version}`;
 }
 
 function getPluginInfo(): string {


### PR DESCRIPTION
- The `version` in `package.json` of a Hypermode Functions plugin is now optional.
- Also now sets `"sdk":"functions-as@0.10.0"` instead of `"library":"@hypermode/functions-as@0.10.0"` in the metadata, to simplify and prepare for additional language support.