### PR TITLE
fix: import issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add functions and example for accessing PostgreSQL [#119](https://github.com/hypermodeAI/functions-as/pull/119)
 - Make plugin version optional [#133](https://github.com/hypermodeAI/functions-as/pull/133)
 - Fix transform display of optional string literal [#134](https://github.com/hypermodeAI/functions-as/pull/134)
+- Fix exporting imported functions or exporting as an alias does not work [#135](https://github.com/hypermodeAI/functions-as/pull/135)
 
 ## 2024-07-10 - Version 0.9.4
 

--- a/src/transform/src/index.ts
+++ b/src/transform/src/index.ts
@@ -21,7 +21,7 @@ export default class HypermodeTransform extends Transform {
           return 0;
         }
       });
-
+    mpgen.sources = sources;
     for (const source of sources) {
       mpgen.visitSource(source);
     }

--- a/src/transform/src/multiparam.ts
+++ b/src/transform/src/multiparam.ts
@@ -255,8 +255,10 @@ function getDefaultValue(param: ParameterNode): string | null {
     case NodeKind.Literal: {
       const literal = param.initializer as LiteralExpression;
       switch (literal.literalKind) {
-        case LiteralKind.String:
-          return (literal as StringLiteralExpression).value;
+        case LiteralKind.String: {
+          const value = (literal as StringLiteralExpression).value;
+          return JSON.stringify(value);
+        }
         case LiteralKind.Integer:
           return (literal as IntegerLiteralExpression).value.toString();
         case LiteralKind.Float:

--- a/src/transform/src/multiparam.ts
+++ b/src/transform/src/multiparam.ts
@@ -147,7 +147,9 @@ export class MultiParamGen {
                 .get(foreignName)
                 ?.push(new NameMeta(foreignName, foreignName, exportedName));
             } else {
-              this.foreign_fns.set(internalPath, [new NameMeta(foreignName, foreignName, exportedName)]);
+              this.foreign_fns.set(internalPath, [
+                new NameMeta(foreignName, foreignName, exportedName),
+              ]);
             }
           }
           this.exported_fns.push(

--- a/src/transform/src/multiparam.ts
+++ b/src/transform/src/multiparam.ts
@@ -140,13 +140,20 @@ export class MultiParamGen {
           const foreignName = node.name.text;
           const internalPath = source.internalPath;
           const exported = isExported(foreignName, source);
+          const exportedName = getExportedName(foreignName, source);
           if (exported) {
             if (this.foreign_fns.has(internalPath)) {
-              this.foreign_fns.get(foreignName).push(new NameMeta(foreignName));
+              this.foreign_fns
+                .get(foreignName)
+                ?.push(new NameMeta(foreignName));
             } else {
               this.foreign_fns.set(internalPath, [new NameMeta(foreignName)]);
             }
           }
+          this.exported_fns.push(
+            new NameMeta(foreignName, foreignName, exportedName),
+          );
+          console.log(this.exported_fns);
         }
       }
     } else if (source.sourceKind === SourceKind.UserEntry) {
@@ -410,7 +417,7 @@ function getExportedName(name: string, source: Source): string {
         for (const member of node.members) {
           const localName = member.localName.text;
           const exportedName = member.exportedName.text;
-          if (name === localName) return localName || exportedName;
+          if (name === localName) return exportedName || localName;
         }
       }
     }
@@ -420,7 +427,7 @@ function getExportedName(name: string, source: Source): string {
 }
 
 function getRealName(name: string, source: Source): string {
-  if (!source.statements) return name;
+  if (!source || !source?.statements) return name;
   for (const stmt of source.statements) {
     if (stmt.kind === NodeKind.Export) {
       const node = stmt as ExportStatement;

--- a/src/transform/src/multiparam.ts
+++ b/src/transform/src/multiparam.ts
@@ -121,7 +121,10 @@ export class MultiParamGen {
     const exportedName = getExportedName(name, source);
     this.optional_fns.set(exportedName, params);
 
-    if (node.flags == CommonFlags.Export || node.flags == CommonFlags.ModuleExport) {
+    if (
+      node.flags == CommonFlags.Export ||
+      node.flags == CommonFlags.ModuleExport
+    ) {
       if (name != exportedName) {
         this.optional_fns.set(name, params);
       }
@@ -153,7 +156,10 @@ export class MultiParamGen {
           for (const node of (stmt as ImportStatement).declarations) {
             const source = node.range.source;
             if (source.sourceKind != SourceKind.UserEntry) return;
-            const foreignName = getRealName(node.foreignName.text, this.sources.find(src => src.internalPath == internalPath));
+            const foreignName = getRealName(
+              node.foreignName.text,
+              this.sources.find((src) => src.internalPath == internalPath),
+            );
             const localName = node.name.text;
             const exported = isExported(localName, source);
             if (!exported) return;
@@ -390,7 +396,9 @@ function isExported(name: string, source: Source): boolean {
 }
 
 function getExportedName(name: string, source: Source): string {
-  const exists = MultiParamGen.SN.exported_fns.find(v => v.foreignName == name);
+  const exists = MultiParamGen.SN.exported_fns.find(
+    (v) => v.foreignName == name,
+  );
   if (exists) return exists.exportedName;
   let i = source.statements.length - 1;
   while (i >= 0) {

--- a/src/transform/src/multiparam.ts
+++ b/src/transform/src/multiparam.ts
@@ -4,7 +4,6 @@ import {
   CommonFlags,
   FloatLiteralExpression,
   FunctionDeclaration,
-  IdentifierExpression,
   IntegerLiteralExpression,
   LiteralExpression,
   LiteralKind,
@@ -22,12 +21,27 @@ import {
   Token,
   Tokenizer,
   ExportStatement,
+  ImportStatement,
 } from "assemblyscript/dist/assemblyscript.js";
 import { Parameter } from "./types.js";
-
 class OptionalParam {
   param: Parameter;
   defaultValue: string | null = null;
+}
+
+class NameMeta {
+  localName: string | null;
+  foreignName: string | null;
+  exportedName: string | null;
+  constructor(
+    localName: string | null = null,
+    foreignName: string | null = null,
+    exportedName: string | null = null,
+  ) {
+    this.localName = localName;
+    this.foreignName = foreignName;
+    this.exportedName = exportedName;
+  }
 }
 
 /**
@@ -63,40 +77,27 @@ class OptionalParam {
  */
 export class MultiParamGen {
   static SN: MultiParamGen = new MultiParamGen();
-  public required_fns: string[] = [];
+  public sources: Source[] = [];
+  public foreign_fns = new Map<string, NameMeta[]>();
+  public foreign_files = new Set<string>();
+
+  public exported_fns: NameMeta[] = [];
   public optional_fns = new Map<string, OptionalParam[]>();
   static init(): MultiParamGen {
     if (!MultiParamGen.SN) MultiParamGen.SN = new MultiParamGen();
     return MultiParamGen.SN;
   }
-  visitExportStatement(node: ExportStatement): void {
-    const source = node.range.source;
-    if (source.sourceKind != SourceKind.UserEntry) return;
-    for (const member of node.members) {
-      const name = member.localName.text;
-      this.required_fns.push(name);
-    }
-  }
   visitFunctionDeclaration(node: FunctionDeclaration) {
     const source = node.range.source;
-    let name = node.name.text;
-    if (!node.body && node.decorators?.length) {
-      const decorator = node.decorators.find(
-        (e) => (e.name as IdentifierExpression).text === "external",
-      );
-      if (
-        decorator.args.length > 1 &&
-        decorator.args[1].kind === NodeKind.Literal
-      ) {
-        name = (decorator.args[1] as StringLiteralExpression).value.toString();
-      }
-    }
+    const name = node.name.text;
+    const exported = isExported(name, source);
+    if (!exported) return;
     if (
       source.sourceKind != SourceKind.UserEntry &&
-      !this.required_fns.includes(name)
+      !this.foreign_fns
+        .get(source.internalPath)
+        ?.find((v) => v.foreignName == name)
     )
-      return;
-    if (node.flags != CommonFlags.Export && !this.required_fns.includes(name))
       return;
     if (node.signature.parameters.length > 63) {
       throw new Error("Functions exceeding 64 parameters not allowed!");
@@ -117,52 +118,101 @@ export class MultiParamGen {
       });
     }
 
-    this.optional_fns.set(name, params);
+    const exportedName = getExportedName(name, source);
+    this.optional_fns.set(exportedName, params);
+
+    if (node.flags == CommonFlags.Export || node.flags == CommonFlags.ModuleExport) {
+      if (name != exportedName) {
+        this.optional_fns.set(name, params);
+      }
+    }
 
     initDefaultValues(node);
-
-    if (node.body == null) {
-      let name = node.name.text;
-      if (!node.body && node.decorators?.length) {
-        const decorator = node.decorators.find(
-          (e) => (e.name as IdentifierExpression).text === "external",
-        );
-        if (
-          decorator.args.length > 1 &&
-          decorator.args[1].kind === NodeKind.Literal
-        ) {
-          name = (
-            decorator.args[1] as StringLiteralExpression
-          ).value.toString();
+  }
+  visitSource(source: Source) {
+    if (this.foreign_files.has(source.internalPath)) {
+      for (const stmt of source.statements) {
+        if (stmt.kind === NodeKind.FunctionDeclaration) {
+          const node = stmt as FunctionDeclaration;
+          const foreignName = node.name.text;
+          const internalPath = source.internalPath;
+          const exported = isExported(foreignName, source);
+          if (exported) {
+            if (this.foreign_fns.has(internalPath)) {
+              this.foreign_fns.get(foreignName).push(new NameMeta(foreignName));
+            } else {
+              this.foreign_fns.set(internalPath, [new NameMeta(foreignName)]);
+            }
+          }
         }
       }
-      const params: OptionalParam[] = [];
-      for (const param of node.signature.parameters) {
-        const defaultValue = getDefaultValue(param);
-        params.push({
-          param: {
-            name: param.name.text,
-            type: {
-              name: "UNINITIALIZED_VALUE",
-              path: "UNINITIALIZED_VALUE",
-            },
-            optional: !!param.initializer,
-          },
-          defaultValue,
-        });
-        if (param.initializer) param.initializer = null;
+    } else if (source.sourceKind === SourceKind.UserEntry) {
+      for (const stmt of source.statements) {
+        if (stmt.kind === NodeKind.Import) {
+          const internalPath = (stmt as ImportStatement).internalPath;
+          for (const node of (stmt as ImportStatement).declarations) {
+            const source = node.range.source;
+            if (source.sourceKind != SourceKind.UserEntry) return;
+            const foreignName = getRealName(node.foreignName.text, this.sources.find(src => src.internalPath == internalPath));
+            const localName = node.name.text;
+            const exported = isExported(localName, source);
+            if (!exported) return;
+            if (this.foreign_fns.has(internalPath)) {
+              this.foreign_fns
+                .get(internalPath)
+                .push(new NameMeta(localName, foreignName));
+            } else {
+              this.foreign_fns.set(internalPath, [
+                new NameMeta(localName, foreignName),
+              ]);
+            }
+          }
+        } else if (stmt.kind === NodeKind.Export) {
+          const node = stmt as ExportStatement;
+          const internalPath = node.internalPath;
+          if (internalPath) {
+            if (node.members?.length) {
+              if (!this.foreign_fns.has(internalPath)) {
+                this.foreign_fns.set(internalPath, []);
+              }
+              const foreign_fns = this.foreign_fns.get(internalPath);
+              for (const member of node.members) {
+                const localName = member.localName.text;
+                const exportedName = member.exportedName.text;
+                const exists = foreign_fns.find(
+                  (v) => v.localName == localName,
+                );
+                if (exists) {
+                  exists.exportedName = exportedName;
+                } else {
+                  foreign_fns.push(
+                    new NameMeta(localName, localName, exportedName),
+                  );
+                }
+              }
+            } else {
+              this.foreign_files.add(internalPath);
+            }
+          } else {
+            if (!node.members?.length) continue;
+            for (const member of node.members) {
+              const localName = member.localName.text;
+              let foreignName: string = localName;
+              for (const v of this.foreign_fns.values()) {
+                for (const value of v) {
+                  if (value.localName === localName)
+                    foreignName = value.foreignName;
+                }
+              }
+              const exportedName = member.exportedName.text;
+              const meta = new NameMeta(localName, foreignName, exportedName);
+              this.exported_fns.push(meta);
+            }
+          }
+        }
       }
-      this.optional_fns.set(name, params);
     }
-  }
-  visitSource(node: Source) {
-    if (node.isLibrary) return;
-    for (const stmt of node.statements) {
-      if (stmt.kind === NodeKind.Export) {
-        this.visitExportStatement(stmt as ExportStatement);
-      }
-    }
-    for (const stmt of node.statements) {
+    for (const stmt of source.statements) {
       if (stmt.kind === NodeKind.FunctionDeclaration) {
         this.visitFunctionDeclaration(stmt as FunctionDeclaration);
       }
@@ -191,10 +241,8 @@ function getDefaultValue(param: ParameterNode): string | null {
     case NodeKind.Literal: {
       const literal = param.initializer as LiteralExpression;
       switch (literal.literalKind) {
-        case LiteralKind.String: {
-          const value = (literal as StringLiteralExpression).value;
-          return JSON.stringify(value);
-        }
+        case LiteralKind.String:
+          return (literal as StringLiteralExpression).value;
         case LiteralKind.Integer:
           return (literal as IntegerLiteralExpression).value.toString();
         case LiteralKind.Float:
@@ -314,4 +362,68 @@ function initDefaultValues(node: FunctionDeclaration) {
       if (param.initializer) param.initializer = null;
     }
   }
+}
+
+function isExported(name: string, source: Source): boolean {
+  let i = source.statements.length - 1;
+  while (i >= 0) {
+    const stmt = source.statements[i];
+    if (stmt.kind === NodeKind.FunctionDeclaration) {
+      const node = stmt as FunctionDeclaration;
+      return (
+        node.flags === CommonFlags.Export ||
+        node.flags === CommonFlags.ModuleExport
+      );
+    } else if (stmt.kind === NodeKind.Export) {
+      const node = stmt as ExportStatement;
+      // export { ... } from "..."
+      if (node.members) {
+        for (const member of node.members) {
+          const localName = member.localName.text;
+          if (name === localName) return true;
+        }
+      }
+    }
+    i--;
+  }
+  return false;
+}
+
+function getExportedName(name: string, source: Source): string {
+  const exists = MultiParamGen.SN.exported_fns.find(v => v.foreignName == name);
+  if (exists) return exists.exportedName;
+  let i = source.statements.length - 1;
+  while (i >= 0) {
+    const stmt = source.statements[i];
+    if (stmt.kind === NodeKind.Export) {
+      const node = stmt as ExportStatement;
+      // export { ... } from "..."
+      if (node.members) {
+        for (const member of node.members) {
+          const localName = member.localName.text;
+          const exportedName = member.exportedName.text;
+          if (name === localName) return localName || exportedName;
+        }
+      }
+    }
+    i--;
+  }
+  return name;
+}
+
+function getRealName(name: string, source: Source): string {
+  if (!source.statements) return name;
+  for (const stmt of source.statements) {
+    if (stmt.kind === NodeKind.Export) {
+      const node = stmt as ExportStatement;
+      if (node.members) {
+        for (const member of node.members) {
+          const localName = member.localName.text;
+          const exportedName = member.exportedName.text;
+          if (name === exportedName) return localName;
+        }
+      }
+    }
+  }
+  return name;
 }

--- a/src/transform/src/multiparam.ts
+++ b/src/transform/src/multiparam.ts
@@ -145,9 +145,9 @@ export class MultiParamGen {
             if (this.foreign_fns.has(internalPath)) {
               this.foreign_fns
                 .get(foreignName)
-                ?.push(new NameMeta(foreignName));
+                ?.push(new NameMeta(foreignName, foreignName, exportedName));
             } else {
-              this.foreign_fns.set(internalPath, [new NameMeta(foreignName)]);
+              this.foreign_fns.set(internalPath, [new NameMeta(foreignName, foreignName, exportedName)]);
             }
           }
           this.exported_fns.push(
@@ -156,7 +156,8 @@ export class MultiParamGen {
           console.log(this.exported_fns);
         }
       }
-    } else if (source.sourceKind === SourceKind.UserEntry) {
+    }
+    if (source.sourceKind === SourceKind.UserEntry) {
       for (const stmt of source.statements) {
         if (stmt.kind === NodeKind.Import) {
           const internalPath = (stmt as ImportStatement).internalPath;


### PR DESCRIPTION
This fixes cases such as:

`index.ts`
```js
import { foo1 as foo2 } from "./foo";

export function bar(a: i32 = 1): void {
  console.log("bar");
  foo2(1, 0b1);
}

export {
  foo2 as foo3,
  bar as bar2
}
```

`foo.ts`
```js
function foo(a: i32 = 1): void {
    console.log("foo");
}

export {
    foo as foo1
}
```

The following are supported
```js
export * from "..."
export { a as b }
export { a }

import * from "..."
import { a } from "..."
import { a as b } from "..."
```