### PR TITLE
Update collections example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Add namespace support for collections [#158](https://github.com/hypermodeAI/functions-as/pull/158)
 - Add getNamespaces host function to collections [#160](https://github.com/hypermodeAI/functions-as/pull/160)
 - Add cross namespace search support to collections [#161](https://github.com/hypermodeAI/functions-as/pull/161)
+- Update collections example [#162](https://github.com/hypermodeAI/functions-as/pull/162)
 
 ## 2024-08-01 - Version 0.10.5
 

--- a/examples/collection/assembly/index.ts
+++ b/examples/collection/assembly/index.ts
@@ -17,25 +17,16 @@ export function embed(text: string[]): f32[][] {
 
 export function addProduct(description: string): string[] {
   const response = collections.upsert(myProducts, null, description);
-  if (!response.isSuccessful) {
-    throw new Error(response.error);
-  }
   return response.keys;
 }
 
 export function addProducts(descriptions: string[]): string[] {
   const response = collections.upsertBatch(myProducts, [], descriptions);
-  if (!response.isSuccessful) {
-    throw new Error(response.error);
-  }
   return response.keys;
 }
 
 export function deleteProduct(key: string): string {
   const response = collections.remove(myProducts, key);
-  if (!response.isSuccessful) {
-    throw new Error(response.error);
-  }
   return response.status;
 }
 


### PR DESCRIPTION
We're already logging the error, so throwing is redundant, creating two error logs for the same error.