### PR TITLE
Lock xid-ts version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## UNRELEASED
+
+- Lock version of `xid-ts` library to resolve build issues [#189](https://github.com/hypermodeAI/functions-as/pull/189)
+
 ## 2024-09-16 - Version 0.12.0
 
 - Update to v2 Hypermode metadata format [#176](https://github.com/hypermodeAI/functions-as/pull/176)

--- a/examples/anthropic-functions/package-lock.json
+++ b/examples/anthropic-functions/package-lock.json
@@ -33,7 +33,7 @@
         "@hypermode/models-as": "^0.2.4",
         "json-as": "^0.9.21",
         "semver": "^7.6.3",
-        "xid-ts": "^1.1.1"
+        "xid-ts": "1.1.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.10.0",

--- a/examples/classification/package-lock.json
+++ b/examples/classification/package-lock.json
@@ -33,7 +33,7 @@
         "@hypermode/models-as": "^0.2.4",
         "json-as": "^0.9.21",
         "semver": "^7.6.3",
-        "xid-ts": "^1.1.1"
+        "xid-ts": "1.1.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.10.0",

--- a/examples/collection/package-lock.json
+++ b/examples/collection/package-lock.json
@@ -33,7 +33,7 @@
         "@hypermode/models-as": "^0.2.4",
         "json-as": "^0.9.21",
         "semver": "^7.6.3",
-        "xid-ts": "^1.1.1"
+        "xid-ts": "1.1.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.10.0",

--- a/examples/dgraph/package-lock.json
+++ b/examples/dgraph/package-lock.json
@@ -32,7 +32,7 @@
         "@hypermode/models-as": "^0.2.4",
         "json-as": "^0.9.21",
         "semver": "^7.6.3",
-        "xid-ts": "^1.1.1"
+        "xid-ts": "1.1.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.10.0",

--- a/examples/embedding/package-lock.json
+++ b/examples/embedding/package-lock.json
@@ -33,7 +33,7 @@
         "@hypermode/models-as": "^0.2.4",
         "json-as": "^0.9.21",
         "semver": "^7.6.3",
-        "xid-ts": "^1.1.1"
+        "xid-ts": "1.1.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.10.0",

--- a/examples/graphql/package-lock.json
+++ b/examples/graphql/package-lock.json
@@ -32,7 +32,7 @@
         "@hypermode/models-as": "^0.2.4",
         "json-as": "^0.9.21",
         "semver": "^7.6.3",
-        "xid-ts": "^1.1.1"
+        "xid-ts": "1.1.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.10.0",

--- a/examples/http/package-lock.json
+++ b/examples/http/package-lock.json
@@ -32,7 +32,7 @@
         "@hypermode/models-as": "^0.2.4",
         "json-as": "^0.9.21",
         "semver": "^7.6.3",
-        "xid-ts": "^1.1.1"
+        "xid-ts": "1.1.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.10.0",

--- a/examples/postgresql/package-lock.json
+++ b/examples/postgresql/package-lock.json
@@ -32,7 +32,7 @@
         "@hypermode/models-as": "^0.2.4",
         "json-as": "^0.9.21",
         "semver": "^7.6.3",
-        "xid-ts": "^1.1.1"
+        "xid-ts": "1.1.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.10.0",

--- a/examples/simple/package-lock.json
+++ b/examples/simple/package-lock.json
@@ -31,7 +31,7 @@
         "@hypermode/models-as": "^0.2.4",
         "json-as": "^0.9.21",
         "semver": "^7.6.3",
-        "xid-ts": "^1.1.1"
+        "xid-ts": "1.1.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.10.0",

--- a/examples/textgeneration/package-lock.json
+++ b/examples/textgeneration/package-lock.json
@@ -33,7 +33,7 @@
         "@hypermode/models-as": "^0.2.4",
         "json-as": "^0.9.21",
         "semver": "^7.6.3",
-        "xid-ts": "^1.1.1"
+        "xid-ts": "1.1.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.10.0",

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -13,7 +13,7 @@
         "@hypermode/models-as": "^0.2.4",
         "json-as": "^0.9.21",
         "semver": "^7.6.3",
-        "xid-ts": "^1.1.1"
+        "xid-ts": "1.1.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.10.0",

--- a/src/package.json
+++ b/src/package.json
@@ -19,7 +19,7 @@
     "@hypermode/models-as": "^0.2.4",
     "json-as": "^0.9.21",
     "semver": "^7.6.3",
-    "xid-ts": "^1.1.1"
+    "xid-ts": "1.1.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.10.0",


### PR DESCRIPTION
#188 was giving build errors.  Digging in, the cause appears to be a change in the package configuration for the latest version of the `xid-ts` library.  I reported a minimal repro at https://github.com/yiwen-ai/xid-ts/issues/11

In the meantime, we should lock to the previous version.